### PR TITLE
fix(script): avoid use short path on import statement

### DIFF
--- a/.github/workflows/import-song.yml
+++ b/.github/workflows/import-song.yml
@@ -6,6 +6,7 @@ on:
       - 'master'
     paths:
       - 'song-info/**'
+      - '.github/workflows/import-song.yml'
 
 jobs:
   build:
@@ -29,13 +30,13 @@ jobs:
         run: npm ci
       - name: Unit Test with Jest
         run: npm test
-      - name: Import Data to Firebase
+      - name: Create master JSON Files & Increment Firestore Version
         run: npm start
         env:
           FIREBASE_CLIENT_EMAIL: ${{ secrets.FIREBASE_CLIENT_EMAIL }}
           FIREBASE_PRIVATE_KEY: ${{ secrets.FIREBASE_PRIVATE_KEY }}
           FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_SDK_PROJECT_ID }}
-      - name: Prettier Created Json
+      - name: Prettier Created JSON
         run: npx prettier -l "./static/*.json" --write
       - name: Push Created Json Files
         run: |

--- a/types/song.ts
+++ b/types/song.ts
@@ -2,7 +2,7 @@ import {
   hasNumberProperty,
   hasProperty,
   hasStringProperty
-} from '~/utils/type-assert'
+} from '../utils/type-assert'
 
 import { isSeries, Series } from './series'
 

--- a/types/song.ts
+++ b/types/song.ts
@@ -1,10 +1,9 @@
+import { isSeries, Series } from './series'
 import {
   hasNumberProperty,
   hasProperty,
   hasStringProperty
 } from '../utils/type-assert'
-
-import { isSeries, Series } from './series'
 
 export type Song = {
   /** ^([01689bdiloqDIOPQ]*){32}$ */

--- a/types/song.ts
+++ b/types/song.ts
@@ -1,9 +1,9 @@
-import { isSeries, Series } from './series'
 import {
   hasNumberProperty,
   hasProperty,
   hasStringProperty
 } from '../utils/type-assert'
+import { isSeries, Series } from './series'
 
 export type Song = {
   /** ^([01689bdiloqDIOPQ]*){32}$ */

--- a/types/step-chart.ts
+++ b/types/step-chart.ts
@@ -2,7 +2,7 @@ import {
   hasNumberProperty,
   hasProperty,
   hasStringProperty
-} from '~/utils/type-assert'
+} from '../utils/type-assert'
 
 import { Difficulty, isDifficulty } from './difficulty'
 import { isLevel, Level } from './level'

--- a/types/step-chart.ts
+++ b/types/step-chart.ts
@@ -1,12 +1,11 @@
+import { Difficulty, isDifficulty } from './difficulty'
+import { isLevel, Level } from './level'
+import { isPlayStyle, PlayStyle } from './play-style'
 import {
   hasNumberProperty,
   hasProperty,
   hasStringProperty
 } from '../utils/type-assert'
-
-import { Difficulty, isDifficulty } from './difficulty'
-import { isLevel, Level } from './level'
-import { isPlayStyle, PlayStyle } from './play-style'
 
 export type StepChart = {
   /** Song's id. */

--- a/types/step-chart.ts
+++ b/types/step-chart.ts
@@ -1,11 +1,11 @@
-import { Difficulty, isDifficulty } from './difficulty'
-import { isLevel, Level } from './level'
-import { isPlayStyle, PlayStyle } from './play-style'
 import {
   hasNumberProperty,
   hasProperty,
   hasStringProperty
 } from '../utils/type-assert'
+import { Difficulty, isDifficulty } from './difficulty'
+import { isLevel, Level } from './level'
+import { isPlayStyle, PlayStyle } from './play-style'
 
 export type StepChart = {
   /** Song's id. */


### PR DESCRIPTION
Import Song scripts cannot resolve short path like `@/foo/bar`, `~/foo/bar`