### PR TITLE
fix: change master JSON URL

### DIFF
--- a/plugins/chart-repository.ts
+++ b/plugins/chart-repository.ts
@@ -31,7 +31,8 @@ export const fetchChartsByLevel = async (
         : l.difficulty - r.difficulty
     )
 
-const masterUrl = 'https://raw.githubusercontent.com/ddradar/ddradar/master/static'
+const masterUrl =
+  'https://raw.githubusercontent.com/ddradar/ddradar/master/static'
 const fetchChartJson = async (useMaster: boolean) => {
   const jsonUrl = `${useMaster ? masterUrl : ''}/chart.json`
   const jsonData = await (await fetch(jsonUrl)).json()

--- a/plugins/chart-repository.ts
+++ b/plugins/chart-repository.ts
@@ -2,7 +2,7 @@ import { Level } from '~/types/level'
 import { PlayStyle } from '~/types/play-style'
 import { isStepChart, StepChart } from '~/types/step-chart'
 
-export const chartVersion = 20200212
+export const chartVersion = 20200227
 
 export const fetchSongCharts = async (
   songId: string,
@@ -31,7 +31,7 @@ export const fetchChartsByLevel = async (
         : l.difficulty - r.difficulty
     )
 
-const masterUrl = 'https://staging.ddradar.app'
+const masterUrl = 'https://raw.githubusercontent.com/ddradar/ddradar/master/static'
 const fetchChartJson = async (useMaster: boolean) => {
   const jsonUrl = `${useMaster ? masterUrl : ''}/chart.json`
   const jsonData = await (await fetch(jsonUrl)).json()

--- a/plugins/song-repository.ts
+++ b/plugins/song-repository.ts
@@ -29,7 +29,8 @@ export const fetchSongById = async (
   return song[0]
 }
 
-const masterUrl = 'https://raw.githubusercontent.com/ddradar/ddradar/master/static'
+const masterUrl =
+  'https://raw.githubusercontent.com/ddradar/ddradar/master/static'
 const fetchSongJson = async (useMaster: boolean) => {
   const jsonUrl = `${useMaster ? masterUrl : ''}/song.json`
   const jsonData = await (await fetch(jsonUrl)).json()

--- a/plugins/song-repository.ts
+++ b/plugins/song-repository.ts
@@ -1,6 +1,6 @@
 import { isSong, Song } from '@/types/song'
 
-export const songVersion = 20200212
+export const songVersion = 20200227
 
 export const fetchSongs = async (
   fieldName: keyof Song,
@@ -29,7 +29,7 @@ export const fetchSongById = async (
   return song[0]
 }
 
-const masterUrl = 'https://staging.ddradar.app'
+const masterUrl = 'https://raw.githubusercontent.com/ddradar/ddradar/master/static'
 const fetchSongJson = async (useMaster: boolean) => {
   const jsonUrl = `${useMaster ? masterUrl : ''}/song.json`
   const jsonData = await (await fetch(jsonUrl)).json()


### PR DESCRIPTION
If PR is merged that update song info, master JSON files (`static/song.json`, `chart.json`) are not included on staging build.
So, unless there are other commits, JSONs are previous version.

This PR fixes it.